### PR TITLE
Delete parsed values from memory to reduce heap usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ function createParseStream() {
 			parser.onValue = function (value) {
 				if (this.stack.length === 1) {
 					self.push(value);
+					this.key--
+					this.value.pop()
 				}
 			};
 			parser.write(chunk);


### PR DESCRIPTION
JSONParse keeps all parsed items in memory in order to return the full array on its last onValue call.
By poping the parent array we release objects from heap as we're not interested in getting the full array from JSONParse.
This reduces heap usage when reading very large json files as previously the whole file would have to be loaded into RAM.